### PR TITLE
Fix: Setting grails.release.scm.enabled to 'false' in BuildConfig is ignored.

### DIFF
--- a/scripts/PublishPlugin.groovy
+++ b/scripts/PublishPlugin.groovy
@@ -54,7 +54,7 @@ target(default: "Publishes a plugin to either a Subversion or Maven repository."
     if (argsMap["snapshot"]) isRelease = false
 
     // Is source control management enabled for this run?
-    def scmEnabled = getPropertyValue("grails.release.scm.enabled", true)
+    def scmEnabled = getPropertyValue("grails.release.scm.enabled", "true").toBoolean()
     scmEnabled = scmEnabled || argsMap["scm"]
     if (argsMap["noScm"]) scmEnabled = false
 


### PR DESCRIPTION
Fix: getPropertyValue returns instances of Strings - thus the returned values
must be converted to Booleans
