### PR TITLE
setting export = false on svn plugin...

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,7 +18,9 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        runtime ":svn:1.0.0.M1"
+        runtime (":svn:1.0.0.M1") {
+            export = false
+        }
     }
 
     dependencies {
@@ -28,7 +30,7 @@ grails.project.dependency.resolution = {
               "org.codehaus.groovy.modules.http-builder:http-builder:0.5.0", {
             excludes "commons-logging", "xml-apis", "groovy"
         }
-        test  "org.gmock:gmock:0.8.0", {
+        test  "org.gmock:gmock:0.8.1", {
             export = false
         }
     }


### PR DESCRIPTION
... because grails constantly shoves it into hosting projects otherwise, and you need to keep removing it.

bumping the version of gmock from 0.8.0 to 0.8.1 as 0.8.0 has some issues which affect certain usage under grails.
