### PR TITLE
Better support for continuous integration/deployment

### DIFF
--- a/scripts/PublishPlugin.groovy
+++ b/scripts/PublishPlugin.groovy
@@ -292,16 +292,21 @@ target(default: "Publishes a plugin to either a Subversion or Maven repository."
 
         def pomFile = pomFileLocation as File
         if (deployer.isVersionAlreadyPublished(pomFile)) {
-            def inputHelper = new CommandLineHelper()
-            def answer = userInput(
-                    inputHelper,
-                    "This version has already been published. Do you want to replace it " +
-                        "(not recommended except for snapshots)? (y,N) ",
-                    "This version of the plugin has already been published.")
-            if (!answer?.equalsIgnoreCase("y")) {
-                event "StatusFinal", ["Plugin publication cancelled."]
-				if (argsMap["no-squash-ok"]) { exit(0) }
-				else { exit(1) }
+			if (argsMap["no-squash-ok"]) {
+				println "This version of the plugin has already been published."
+				event "StatusFinal", ["Plugin publication cancelled with clean exit."]
+				exit(0)
+			} else {
+				def inputHelper = new CommandLineHelper()
+				def answer = userInput(
+						inputHelper,
+						"This version has already been published. Do you want to replace it " +
+							"(not recommended except for snapshots)? (y,N) ",
+						"This version of the plugin has already been published.")
+				if (!answer?.equalsIgnoreCase("y")) {
+					event "StatusFinal", ["Plugin publication cancelled."]
+					exit(1)
+				}
             }
         }
 

--- a/scripts/PublishPlugin.groovy
+++ b/scripts/PublishPlugin.groovy
@@ -17,35 +17,40 @@ where
                a Subversion repository or a Maven-compatible one.
                (default: Grails Central Plugin Repository).
 
-    PROTOCOL = The protocol to use when deploying to a Maven-compatible repository.
-               Can be one of 'http', 'scp', 'scpexe', 'ftp', or 'webdav'.
-               (default: 'http').
+    PROTOCOL = The protocol to use when deploying to a Maven-compatible
+               repository. Can be one of 'http', 'scp', 'scpexe', 'ftp', or
+               'webdav'. (default: 'http').
 
     PORTAL   = The portal to inform of the plugin's release.
                (default: Grails Plugin Portal).
 
-    MESSAGE  = Commit message to use when committing source changes using your SCM
-               provider.
+    MESSAGE  = Commit message to use when committing source changes using your
+               SCM provider.
 
-    --dry-run    = Shows you what will happen when you publish the plugin, but doesn't
-                   actually publish it.
+    --dry-run      = Shows you what will happen when you publish the plugin,
+                     but doesn't actually publish it.
 
-    --snapshot  = Force this release to be a snapshot version, i.e. it isn't automatically
-                  made the latest available release.
+    --snapshot     = Force this release to be a snapshot version, i.e. it isn't
+                     automatically made the latest available release.
 
-    --scm       = Enables source control management for this release.
+    --scm          = Enables source control management for this release.
 
-    --no-scm     = Disables source control management for this release.
+    --no-scm       = Disables source control management for this release.
 
 
-    --no-message = Commit using just the default message.
+    --no-message   = Commit using just the default message.
 
-    --ping-only  = Don't publish/deploy the plugin, only send a notification to the
-                   plugin portal. This is useful if portal notification failed during a
-                   previous attempt to publish the plugin. Mutually exclusive with the
-                   --dry-run option.
+    --no-squash-ok = Don't fail if this plugin has already been published.
+                     This is useful if this plugin is being published from a 
+                     continuous integration server and you don't want the 
+                     command to exit with failure.
 
-    --binary    = Release as a binary plugin.
+    --ping-only    = Don't publish/deploy the plugin, only send a notification
+                     to the plugin portal. This is useful if portal
+                     notification failed during a previous attempt to publish
+                     the plugin. Mutually exclusive with the --dry-run option.
+
+    --binary       = Release as a binary plugin.
 """
 
 scmProvider = null
@@ -59,6 +64,7 @@ target(default: "Publishes a plugin to either a Subversion or Maven repository."
     if (argsMap["noScm"]) { argsMap["no-scm"] = true }
     if (argsMap["noMessage"]) { argsMap["no-message"] = true }
     if (argsMap["pingOnly"]) { argsMap["ping-only"] = true }
+    if (argsMap["noSquashOk"]) { argsMap["no-squash-ok"] = true }
 
     // Read the plugin information from the POM.
     pluginInfo = new XmlSlurper().parse(new File(pomFileLocation))
@@ -294,7 +300,8 @@ target(default: "Publishes a plugin to either a Subversion or Maven repository."
                     "This version of the plugin has already been published.")
             if (!answer?.equalsIgnoreCase("y")) {
                 event "StatusFinal", ["Plugin publication cancelled."]
-                exit(1)
+				if (argsMap["no-squash-ok"]) { exit(0) }
+				else { exit(1) }
             }
         }
 

--- a/src/docs/ref/Command Line/publish-plugin.gdoc
+++ b/src/docs/ref/Command Line/publish-plugin.gdoc
@@ -9,7 +9,7 @@ h2. Options
 {code}
 grails publish-plugin [--dryRun] [--snapshot] [--repository=repoId]
                       [--protocol=protocol] [--portal=portal] [--pingOnly]
-                      [--scm] [--noScm] [--binary]
+                      [--scm] [--noScm] [--binary] [--no-squash-ok]
 {code}
 
 * @dryRun@ will simply print out what files will be deployed. It won't actually perform the deployment, so it's a good way to see whether the command will do what you expect.
@@ -21,6 +21,7 @@ grails publish-plugin [--dryRun] [--snapshot] [--repository=repoId]
 * @scm@ enables source control management for this release. It is on by default unless disabled via the @grails.release.scm.enabled@ configuration setting.
 * @noScm@ disables source control management for this release.
 * @binary@ packages the plugin in binary form before publishing it. This overrides the default packaging for the plugin.
+* @noSquashOk@ ensures the script exits with a status of 0 if this plugin has already been published.  This is useful if this plugin is being published from a continuous integration server and you don't want the command to exit with failure.
 
 h2. Examples
 


### PR DESCRIPTION
This adds a flag (no-squash-ok) to allow the command to exit with a status of 0 from the PublishPlugin script when it is called from an automated build process that automatically publishes the plugin.  This way the build won't fail just because the plugin version is already published.
