### PR TITLE
Ignore pom.xml during generatePom if grails.project.dependency.resolution contains "pom(false)"

### DIFF
--- a/scripts/_GrailsMaven.groovy
+++ b/scripts/_GrailsMaven.groovy
@@ -176,11 +176,16 @@ target(generatePom: "Generates a pom.xml file for the current project unless './
     pomFileLocation = "${grailsSettings.projectTargetDir}/pom.xml"
     basePom = new File("${basedir}/pom.xml")
 
-    if (basePom.exists()) {
-        pomFileLocation = basePom.absolutePath
-        event("StatusUpdate", ["Skipping POM generation because 'pom.xml' exists in the root of the project."])
-        return 1
-    }
+	if (basePom.exists()) {
+		// ignore base pom unless BuildConfig has explicitly set 'pom true'
+		if (grailsSettings.dependencyManager.readPom) {
+	        pomFileLocation = basePom.absolutePath
+	        event("StatusUpdate", ["Skipping POM generation, using existing 'pom.xml' from the root of the project."])
+	        return 0
+		} else {
+	    	event("StatusUpdate", ["Ignoring existing 'pom.xml' from the root of the project. Set 'pom true' to force use of existing pom.xml."])			
+		}
+	}
 
     event("StatusUpdate", ["Generating POM file..."])
     new File(pomFileLocation).withWriter('UTF-8') { w ->


### PR DESCRIPTION
This allows the selera grails-wrapper-plugin to use the release plugin.

With the wrapper approach, a very trivial pom.xml is used to drive the build lifecycle, but the grails module dependencies are still managed entirely within grails via BuildConfig.groovy, like a 'normal' grails project.

So when we are installing a binary plugin into the local m2 repo via "maven-install", we want the release plugin to ignore this trivial driver pom (which doesn't have any dependency information) and generate a pom the same way it would if the pom didn't exist.

Using "pom false" inside BuildConfig.groovy looks like a clean and meaningful way to convey this to the grails subsystem. No mean side effects. No impact to grails users who don't use the wrapper plugin - aka 99.99% of grails users :-)
