### PR TITLE
Problems with json and clausure fixed

### DIFF
--- a/scripts/PublishPlugin.groovy
+++ b/scripts/PublishPlugin.groovy
@@ -420,9 +420,10 @@ target(default: "Publishes a plugin to either a Subversion or Maven repository."
         def converterConfig = new org.codehaus.groovy.grails.web.converters.configuration.ConvertersConfigurationInitializer()
         converterConfig.initialize(grailsApp)
         def rest = classLoader.loadClass("grails.plugins.rest.client.RestBuilder").newInstance()
+		def jsonParams = pluginInfo + [ url : repo.uri.toString() ] 
         def resp = rest.put(portalUrl.toString()) {
             auth username, password
-            json( pluginInfo + [ url : repo.uri.toString() ] )
+            json({ jsonParams })
         }
         switch(resp.status) {
             case 401:

--- a/src/groovy/grails/plugins/publish/Repository.groovy
+++ b/src/groovy/grails/plugins/publish/Repository.groovy
@@ -6,7 +6,7 @@ package grails.plugins.publish
  */
 class Repository {
     /** URL for 'grailsCentral' portal */
-    static final String GRAILS_CENTRAL_PORTAL_URL = "http://grails.org/plugin/"
+    static final String GRAILS_CENTRAL_PORTAL_URL = "http://grails.org/plugins/"
 
     /** The standard Grails Central repository. */
     static final Repository grailsCentral = new Repository(

--- a/src/groovy/grails/plugins/publish/portal/GrailsCentralDeployer.groovy
+++ b/src/groovy/grails/plugins/publish/portal/GrailsCentralDeployer.groovy
@@ -12,7 +12,7 @@ import grails.plugins.rest.client.RestBuilder
 class GrailsCentralDeployer implements PluginDeployer {
 
     //private proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8888))
-    RestBuilder rest = new RestBuilder(connectTimeout: 1000, readTimeout: 10000, proxy: null)
+    RestBuilder rest = new RestBuilder(connectTimeout: 10000, readTimeout: 100000, proxy: null)
     String portalUrl = "http://grails.org/plugins"
     String username
     String password


### PR DESCRIPTION
Hello,

  In 2.2.0 version I think you must call json with clausure in publish script, no with maps. Another problem is the url for: GRAILS_CENTRAL_PORTAL_URL.

  And for me is better to extend  connectTimeout and readTimeout to 10000

  Thank you.
