### PR TITLE
Problems with json and clausure fixed

### DIFF
--- a/scripts/PublishPlugin.groovy
+++ b/scripts/PublishPlugin.groovy
@@ -420,9 +420,10 @@ target(default: "Publishes a plugin to either a Subversion or Maven repository."
         def converterConfig = new org.codehaus.groovy.grails.web.converters.configuration.ConvertersConfigurationInitializer()
         converterConfig.initialize(grailsApp)
         def rest = classLoader.loadClass("grails.plugins.rest.client.RestBuilder").newInstance()
+		def jsonParams = pluginInfo + [ url : repo.uri.toString() ] 
         def resp = rest.put(portalUrl.toString()) {
             auth username, password
-            json( pluginInfo + [ url : repo.uri.toString() ] )
+            json({ jsonParams })
         }
         switch(resp.status) {
             case 401:

--- a/src/groovy/grails/plugins/publish/portal/GrailsCentralDeployer.groovy
+++ b/src/groovy/grails/plugins/publish/portal/GrailsCentralDeployer.groovy
@@ -12,7 +12,7 @@ import grails.plugins.rest.client.RestBuilder
 class GrailsCentralDeployer implements PluginDeployer {
 
     //private proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8888))
-    RestBuilder rest = new RestBuilder(connectTimeout: 1000, readTimeout: 10000, proxy: null)
+    RestBuilder rest = new RestBuilder(connectTimeout: 10000, readTimeout: 100000, proxy: null)
     String portalUrl = "http://grails.org/plugins"
     String username
     String password


### PR DESCRIPTION
Hello,

  I resubmited  in a new branch the pull#10. The url for GRAILS_CENTRAL_PORTAL_URL is not commited, but i'm not sure if this is a bug or not.

  Regards

---

Hello,

In 2.2.0 version I think you must call json with clausure in publish script, no with maps. Another problem is the url for: GRAILS_CENTRAL_PORTAL_URL.

And for me is better to extend connectTimeout and readTimeout to 10000

Thank you.
