### PR TITLE
GPRELEASE-42 Change scope for dependencies to "compile", as "provided" a...

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,8 +21,8 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-        provided "org.apache.ivy:ivy:2.2.0"
-        provided("org.apache.maven:maven-ant-tasks:2.1.3") {
+        compile "org.apache.ivy:ivy:2.2.0"
+        compile("org.apache.maven:maven-ant-tasks:2.1.3") {
             excludes "commons-logging", "xml-apis", "groovy"
         }
         test("org.gmock:gmock:0.8.0") {


### PR DESCRIPTION
...nd "build" no longer will be resolved by application for plugin dependencies.

Ref http://grails.org/doc/2.2.0/guide/upgradingFromPreviousVersionsOfGrails.html section "Upgrading to 2.2 from 2.1 or 2.0" and http://grails.1312388.n4.nabble.com/legacyResolve-and-dependencies-with-scope-quot-provided-quot-td4641607.html#a4641610
