### PR TITLE
New command line option --forcePomGeneration to ignore existing pom.xml

### DIFF
--- a/scripts/_GrailsMaven.groovy
+++ b/scripts/_GrailsMaven.groovy
@@ -187,16 +187,16 @@ target(generatePom: "Generates a pom.xml file for the current project unless './
     pomFileLocation = "${grailsSettings.projectTargetDir}/pom.xml"
     basePom = new File(basedir, "pom.xml")
 
-	if (basePom.exists()) {
-		// ignore base pom unless BuildConfig has explicitly set 'pom true'
-		if (grailsSettings.dependencyManager.readPom) {
-	        pomFileLocation = basePom.absolutePath
-	        event("StatusUpdate", ["Skipping POM generation, using existing 'pom.xml' from the root of the project."])
-	        return 0
-		} else {
-	    	event("StatusUpdate", ["Ignoring existing 'pom.xml' from the root of the project. Set 'pom true' to force use of existing pom.xml."])			
-		}
-	}
+    if (basePom.exists()) {
+		forcePomGeneration = argsMap.forcePomGeneration ?: false
+        if (forcePomGeneration) {
+            event("StatusUpdate", ["Forcing POM generation, ignoring 'pom.xml' in the root of the project."])
+        } else {
+            pomFileLocation = basePom.absolutePath
+            event("StatusUpdate", ["Skipping POM generation because 'pom.xml' exists in the root of the project."])
+            return 1
+        }
+    }
 
     event("StatusUpdate", ["Generating POM file..."])
     new File(pomFileLocation).withWriter('UTF-8') { w ->


### PR DESCRIPTION
This CLI option allows the plugin to ignore an existing pom.xml in the root of the project directory and force generation of a new temporary pom for use with maven-install or maven-deploy.

This is very useful if you use maven to control a much larger multi-module project build, of which the grails plugin or application is only one module in a larger project. Our company use maven to drive our product build, but it invoke the grails build for the module via cli. This means that the dependencies for the project are defined entirely within BuildConfig.groovy and not in the "driver" pom.

I realise that very few people will use this option. It is false by default, and is a very simple implementation and no complex logic. Let me know if you'd like it to work differently, or you'd like it documented in the readme.
