### PR TITLE
Change target name from 'default' to 'publishPlugin' to allow target to be called from other scripts

### DIFF
--- a/scripts/PublishPlugin.groovy
+++ b/scripts/PublishPlugin.groovy
@@ -52,7 +52,7 @@ where
 scmProvider = null
 scmHost = null
 
-target(default: "Publishes a plugin to either a Subversion or Maven repository.") {
+target(publishPlugin: "Publishes a plugin to either a Subversion or Maven repository.") {
     depends(parseArguments, checkGrailsVersion, packagePlugin, processDefinitions, generatePom)
 
     // Handle old names for options. Trying to be consistent with Grails 2.0 conventions.
@@ -572,3 +572,5 @@ private scmImportProject(scm, inputHelper, msg) {
 
     scmProvider.importIntoRepo hostUrl, "Initial import of plugin source code for the release of version ${pluginInfo.version}.${msg}"
 }
+
+setDefaultTarget(publishPlugin)


### PR DESCRIPTION
I am trying to integrate the grails-release plugin into an automated CI workflow, and the 'default'; name for a target appears to not work when attempting to make use of PublishPlugin.groovy from another script.

Rather than loading the script manually as a File object, or executing a command-line expression, changing the target name to something accessible seems to be a cleaner solution.

With this change, I can use:

```
    includeTargets << new File("$releasePluginDir/scripts/PublishPlugin.groovy")
```

and 

```
    depends(publishPlugin)
```

to include it in my workflow (with appropriate script arguments).
