### PR TITLE
non-plugin generate pom bugfix

### DIFF
--- a/scripts/_GrailsMaven.groovy
+++ b/scripts/_GrailsMaven.groovy
@@ -307,10 +307,9 @@ target(generatePom: "Generates a pom.xml file for the current project unless './
                 name grailsAppName
             }
 
-            def excludeResolver = grailsSettings.dependencyManager.excludeResolver
-            def excludeInfo = excludeResolver.resolveExcludes()
-
             if (plugin) {
+                def excludeResolver = grailsSettings.dependencyManager.excludeResolver
+                def excludeInfo = excludeResolver.resolveExcludes()
                 dependencies {
                     def excludeHandler = { dep ->
                         if (dep.transitive == false) {


### PR DESCRIPTION
generate-pom was failing for a non-plugin on the 2 moved variable declarations that are not ever used when generating the pom