### PR TITLE
Minor optimization of app POM file generation

### DIFF
--- a/scripts/_GrailsMaven.groovy
+++ b/scripts/_GrailsMaven.groovy
@@ -307,10 +307,10 @@ target(generatePom: "Generates a pom.xml file for the current project unless './
                 name grailsAppName
             }
 
-            def excludeResolver = grailsSettings.dependencyManager.excludeResolver
-            def excludeInfo = excludeResolver.resolveExcludes()
-
             if (plugin) {
+                def excludeResolver = grailsSettings.dependencyManager.excludeResolver
+                def excludeInfo = excludeResolver.resolveExcludes()
+
                 dependencies {
                     def excludeHandler = { dep ->
                         if (dep.transitive == false) {


### PR DESCRIPTION
Skip `resolveExcludes()` in case of generating POM file for app (not for plugin)