### PR TITLE
Provide remote repository (maven central) for install-provider artifact

### DIFF
--- a/ReleaseGrailsPlugin.groovy
+++ b/ReleaseGrailsPlugin.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 class ReleaseGrailsPlugin {
-    def version = "3.1.2"
+    def version = "3.1.3-SNAPSHOT"
     def grailsVersion = "2.3 > *"
     def author = "Graeme Rocher"
     def authorEmail = "grocher@gopivotal.com"

--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,1 @@
-app.grails.version=2.5.4
+app.grails.version=2.5.6

--- a/scripts/_GrailsMaven.groovy
+++ b/scripts/_GrailsMaven.groovy
@@ -93,7 +93,9 @@ target(mavenDeploy:"Deploys the plugin to a Maven repository") {
 
     if (retval) exit retval
 
-    artifact.'install-provider'(artifactId:protocol, version:"1.0-beta-2")
+    artifact.'install-provider'(artifactId:protocol, version:"1.0-beta-2") {
+        remoteRepository(url: "https://repo1.maven.org/maven2")
+    }
 
     def deployFile = isPlugin ? new File(pluginZip) : grailsSettings.projectWarFile
     def ext = isPlugin ? deployFile.name[-3..-1] : "war"


### PR DESCRIPTION
This fixes an issue where maven-deploy fails when it tries to fetch `org.apache.maven.wagon:wagon-http:jar:1.0-beta-2` dependency using hardcoded maven central repo using maven-ant-tasks.

Should probably be fixed there but I figured this solved the issue.