### PR TITLE
Fixing simple method typo 

### DIFF
--- a/scripts/PublishPlugin.groovy
+++ b/scripts/PublishPlugin.groovy
@@ -213,7 +213,7 @@ target(publishPlugin: "Publishes a plugin to a Maven repository.") {
 
         if (argsMap["prompt-auth"]) {
             def inputHelper = new CommandLineHelper()
-            username = usernput(
+            username = userInput(
                     inputHelper,
                     "Username for repository: ",
                     "You haven't configured the plugin repository username - required in non-interactive mode")


### PR DESCRIPTION
The method is userInput used when prompting for authentication when deploying to remote repo
This was a simple typo with the I missing from the method name.